### PR TITLE
 Backend: Fix #2; make server time configurable

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -222,7 +222,12 @@ func getSources(config *ini.File) ([]SourceConfig, error) {
 		// Set backend
 		switch backendType {
 		case SOURCE_BIRDWATCHER:
-			backendConfig.MapTo(&config.Birdwatcher)
+			c = &config.Birdwatcher{
+				ServerTime:      "2006-01-02T15:04:05.999999999Z07:00",
+				ServerTimeShort: "2006-01-02",
+				ServerTimeExt:   "Mon, 02 Jan 2006 15:04:05 -0700",
+			}
+			backendConfig.MapTo(c)
 			config.Birdwatcher.Id = config.Id
 			config.Birdwatcher.Name = config.Name
 		}

--- a/backend/sources/birdwatcher/config.go
+++ b/backend/sources/birdwatcher/config.go
@@ -4,7 +4,10 @@ type Config struct {
 	Id   int
 	Name string
 
-	Api            string `ini:"api"`
-	Timezone       string `ini:"timezone"`
-	ShowLastReboot bool   `ini:"show_last_reboot"`
+	Api             string `ini:"api"`
+	Timezone        string `ini:"timezone"`
+	ServerTime      string `ini:"servertime"`
+	ServerTimeShort string `ini:"servertime_short"`
+	ServerTimeExt   string `ini:"servertime_ext"`
+	ShowLastReboot  bool   `ini:"show_last_reboot"`
 }

--- a/backend/sources/birdwatcher/parsers.go
+++ b/backend/sources/birdwatcher/parsers.go
@@ -11,10 +11,6 @@ import (
 	"github.com/ecix/alice-lg/backend/api"
 )
 
-const SERVER_TIME = time.RFC3339Nano
-const SERVER_TIME_SHORT = "2006-01-02 15:04:05"
-const SERVER_TIME_EXT = "Mon, 2 Jan 2006 15:04:05 +0000"
-
 // Convert server time string to time
 func parseServerTime(value interface{}, layout, timezone string) (time.Time, error) {
 	svalue, ok := value.(string)
@@ -38,7 +34,7 @@ func parseApiStatus(bird ClientResponse, config Config) (api.ApiStatus, error) {
 
 	ttl, err := parseServerTime(
 		bird["ttl"],
-		SERVER_TIME,
+		config.ServerTime,
 		config.Timezone,
 	)
 	if err != nil {
@@ -61,19 +57,19 @@ func parseBirdwatcherStatus(bird ClientResponse, config Config) (api.Status, err
 	// Get special fields
 	serverTime, _ := parseServerTime(
 		birdStatus["current_server"],
-		SERVER_TIME_SHORT,
+		config.ServerTimeShort,
 		config.Timezone,
 	)
 
 	lastReboot, _ := parseServerTime(
 		birdStatus["last_reboot"],
-		SERVER_TIME_SHORT,
+		config.ServerTimeShort,
 		config.Timezone,
 	)
 
 	lastReconfig, _ := parseServerTime(
 		birdStatus["last_reconfig"],
-		SERVER_TIME_EXT,
+		config.ServerTimeExt,
 		config.Timezone,
 	)
 
@@ -93,7 +89,7 @@ func parseBirdwatcherStatus(bird ClientResponse, config Config) (api.Status, err
 
 // Parse neighbour uptime
 func parseRelativeServerTime(uptime interface{}, config Config) time.Duration {
-	serverTime, _ := parseServerTime(uptime, SERVER_TIME_SHORT, config.Timezone)
+	serverTime, _ := parseServerTime(uptime, config.ServerTimeShort, config.Timezone)
 	return time.Since(serverTime)
 }
 

--- a/client/components/routeservers/routes/routes.jsx
+++ b/client/components/routeservers/routes/routes.jsx
@@ -62,9 +62,9 @@ class RoutesTable extends React.Component {
       return split;
     }
 
-    let routesView = routes.map((r) => {
+    let routesView = routes.map((r,i) => {
       return (
-        <tr key={r.network} onClick={() => this.showAttributesModal(r)}>
+        <tr key={`${r.network}_${i}`} onClick={() => this.showAttributesModal(r)}>
           <td>
             {r.network}
             {this.props.display_reasons == "filtered" && <FilterReason route={r} />}

--- a/etc/alicelg/alice.example.conf
+++ b/etc/alicelg/alice.example.conf
@@ -47,6 +47,10 @@ api = http://rs1.example.com:29184/
 # Optional:
 show_last_reboot = true
 timezone = UTC
+# Also optional: examples for time format
+servertime = 2006-01-02T15:04:05.999999999Z07:00
+servertime_short = 2006-01-02
+servertime_ext = Mon, 02 Jan 2006 15:04:05 -0700
 
 [source.1]
 name = rs1.example.com (IPv6)


### PR DESCRIPTION
This PR fixes #2 by moving timestamp formats to the config; the default values stay the same, they’re injected at config creation time and can be overridden.

Due to a git derp, this needs to be merged after #8, because I can’t use git for shit.

Cheers

CC @job